### PR TITLE
Add print stylesheet for PDF export

### DIFF
--- a/scripts/cgm.py
+++ b/scripts/cgm.py
@@ -2745,6 +2745,132 @@ def generate_html_report(days=90, output_path=None):
                 font-size: 1.8rem;
             }
         }
+        
+        /* Print Styles */
+        @media print {
+            body {
+                background: white !important;
+                color: #000 !important;
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+            
+            .container {
+                max-width: 100%%;
+                padding: 10px;
+            }
+            
+            /* Hide interactive elements */
+            .date-controls,
+            .print-button,
+            .alerts-toggle,
+            .compare-toggle,
+            .alerts-expand,
+            .compare-controls {
+                display: none !important;
+            }
+            
+            /* Force expand collapsed sections */
+            .alerts-section.collapsed .alerts-body,
+            .compare-section.collapsed .compare-body {
+                display: block !important;
+            }
+            
+            /* Page breaks */
+            .chart-section,
+            .stats-grid,
+            .alerts-section,
+            .compare-section {
+                page-break-inside: avoid;
+                margin-bottom: 20px;
+            }
+            
+            header {
+                page-break-after: avoid;
+            }
+            
+            /* Light backgrounds for printing - remove dark theme */
+            .alerts-section,
+            .compare-section,
+            .chart-section,
+            .heatmap-container,
+            .weekly-summary {
+                background: white !important;
+                border: 1px solid #ddd !important;
+            }
+            
+            .disclaimer {
+                background: #f5f5f5 !important;
+                border-color: #666 !important;
+            }
+            
+            .stat-card {
+                background: #f9f9f9 !important;
+                border: 1px solid #ddd !important;
+                color: #000 !important;
+            }
+            
+            .stat-card .value,
+            .stat-card .label {
+                color: #000 !important;
+            }
+            
+            .alert-item {
+                background: #f9f9f9 !important;
+            }
+            
+            .compare-period {
+                background: #f9f9f9 !important;
+            }
+            
+            .alerts-header,
+            .compare-header {
+                color: #000 !important;
+            }
+            
+            h2, h3, h4 {
+                color: #000 !important;
+            }
+            
+            .tir-breakdown {
+                background: transparent !important;
+            }
+            
+            /* Footer */
+            footer {
+                page-break-before: avoid;
+            }
+        }
+        
+        /* Print button */
+        .print-button {
+            position: fixed;
+            bottom: 20px;
+            right: 20px;
+            background: var(--accent);
+            color: white;
+            border: none;
+            padding: 12px 24px;
+            border-radius: 8px;
+            font-size: 1rem;
+            cursor: pointer;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            z-index: 1000;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        
+        .print-button:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 16px rgba(0,0,0,0.4);
+        }
+        
+        .print-button::before {
+            content: '🖨️';
+            font-size: 1.2rem;
+        }
     </style>
 </head>
 <body>
@@ -4225,6 +4351,9 @@ def generate_html_report(days=90, output_path=None):
             return parts.join(' • ');
         }
     </script>
+    
+    <!-- Print Button -->
+    <button class="print-button" onclick="window.print()">Print / Save PDF</button>
 </body>
 </html>
 '''

--- a/scripts/cgm.py
+++ b/scripts/cgm.py
@@ -2760,27 +2760,30 @@ def generate_html_report(days=90, output_path=None):
                 padding: 10px;
             }
             
-            /* Hide interactive elements */
+            /* Force heatmap colors to print */
+            .heatmap-cell {
+                -webkit-print-color-adjust: exact !important;
+                print-color-adjust: exact !important;
+            }
+            
+            /* Hide interactive elements and compare section */
             .date-controls,
             .print-button,
             .alerts-toggle,
-            .compare-toggle,
             .alerts-expand,
-            .compare-controls {
+            .compare-section {
                 display: none !important;
             }
             
-            /* Force expand collapsed sections */
-            .alerts-section.collapsed .alerts-body,
-            .compare-section.collapsed .compare-body {
+            /* Force expand alerts section */
+            .alerts-section.collapsed .alerts-body {
                 display: block !important;
             }
             
             /* Page breaks */
             .chart-section,
             .stats-grid,
-            .alerts-section,
-            .compare-section {
+            .alerts-section {
                 page-break-inside: avoid;
                 margin-bottom: 20px;
             }
@@ -2789,14 +2792,23 @@ def generate_html_report(days=90, output_path=None):
                 page-break-after: avoid;
             }
             
-            /* Light backgrounds for printing - remove dark theme */
+            /* Fix chart clipping - give more height for axis labels */
+            .chart-container {
+                height: 400px !important;
+                overflow: visible !important;
+            }
+            
+            .chart-container.tall {
+                height: 500px !important;
+            }
+            
+            /* White backgrounds for sections */
             .alerts-section,
-            .compare-section,
             .chart-section,
             .heatmap-container,
             .weekly-summary {
                 background: white !important;
-                border: 1px solid #ddd !important;
+                border: 1px solid #ccc !important;
             }
             
             .disclaimer {
@@ -2806,12 +2818,11 @@ def generate_html_report(days=90, output_path=None):
             
             .stat-card {
                 background: #f9f9f9 !important;
-                border: 1px solid #ddd !important;
-                color: #000 !important;
+                border: 1px solid #ccc !important;
             }
             
-            .stat-card .value,
-            .stat-card .label {
+            /* Dark text for headings and labels */
+            h1, h2, h3, h4, .stat-card .label {
                 color: #000 !important;
             }
             
@@ -2819,21 +2830,16 @@ def generate_html_report(days=90, output_path=None):
                 background: #f9f9f9 !important;
             }
             
-            .compare-period {
-                background: #f9f9f9 !important;
-            }
-            
-            .alerts-header,
-            .compare-header {
+            /* Fix alert text visibility */
+            .alert-item,
+            .alert-item *,
+            .alerts-body,
+            .alerts-body * {
                 color: #000 !important;
             }
             
-            h2, h3, h4 {
+            .alerts-header h2 {
                 color: #000 !important;
-            }
-            
-            .tir-breakdown {
-                background: transparent !important;
             }
             
             /* Footer */


### PR DESCRIPTION
Adds print/PDF support using CSS media queries instead of WeasyPrint dependency.

## Changes
- Print button (🖨️ Print / Save PDF) in bottom-right corner
- @media print CSS hides interactive controls and Compare Periods
- Auto-expands Trend Alerts section
- White backgrounds for better printing
- Forces heatmap colors with print-color-adjust

## Known Issues
- Some charts may overflow slightly to the right in print preview

Supersedes #22 (WeasyPrint approach)